### PR TITLE
중복된 시스템 관리자 체크 삭제

### DIFF
--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -14,9 +14,6 @@ class OrganizationPolicy
      */
     public function create(User $user): bool
     {
-        // 조직 생성 권한이 있는 역할을 가진 사용자만 생성 가능
-        // 예: 시스템 관리자이거나 조직 생성 권한을 가진 사용자
-        return $user->hasPermission('organization.create')
-            || $user->hasRole('system-admin');
+        return $user->hasPermission('organization.create');
     }
 }


### PR DESCRIPTION
resolved #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 조직 생성 권한 검증에서 `system-admin` 역할에 대한 예외 처리가 제거되어, 이제 `organization.create` 권한이 있는 사용자만 조직을 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->